### PR TITLE
chore: bump `eslint-config-mixmax` to enforce return-await

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "integration-testing-for-humans",
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
@@ -30,7 +31,7 @@
         "cz-conventional-changelog": "^3.3.0",
         "del-cli": "^3.0.1",
         "eslint": "^7.32.0",
-        "eslint-config-mixmax": "^5.0.1",
+        "eslint-config-mixmax": "^5.1.0",
         "jest": "^27.3.1",
         "prettier": "^2.4.1",
         "semantic-release": "^17.4.7",
@@ -7530,9 +7531,9 @@
       }
     },
     "node_modules/eslint-config-mixmax": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-mixmax/-/eslint-config-mixmax-5.0.1.tgz",
-      "integrity": "sha512-Fqi2/Bzs5k18V91q1rGHXm0Tz12ZB1DmzcxSSTp6TNDoBN2+YbBjNnVP38mMpWrN1nelZIdRob0xPkRUAdRUbQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-mixmax/-/eslint-config-mixmax-5.1.0.tgz",
+      "integrity": "sha512-KoJdfGkX7KIRiuNT0XaQrTja9y3oo6IU03PWXWA9gOJAZDp2aeJgnCThwguAEek1dYJb0s2ANC8xbQB4AfS6lg==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/parser": "^4.32.0",
@@ -15244,6 +15245,11 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -24987,9 +24993,9 @@
       }
     },
     "eslint-config-mixmax": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-mixmax/-/eslint-config-mixmax-5.0.1.tgz",
-      "integrity": "sha512-Fqi2/Bzs5k18V91q1rGHXm0Tz12ZB1DmzcxSSTp6TNDoBN2+YbBjNnVP38mMpWrN1nelZIdRob0xPkRUAdRUbQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-mixmax/-/eslint-config-mixmax-5.1.0.tgz",
+      "integrity": "sha512-KoJdfGkX7KIRiuNT0XaQrTja9y3oo6IU03PWXWA9gOJAZDp2aeJgnCThwguAEek1dYJb0s2ANC8xbQB4AfS6lg==",
       "dev": true,
       "requires": {
         "@babel/eslint-parser": "^7.16.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "cz-conventional-changelog": "^3.3.0",
     "del-cli": "^3.0.1",
     "eslint": "^7.32.0",
-    "eslint-config-mixmax": "^5.0.1",
+    "eslint-config-mixmax": "^5.1.0",
     "jest": "^27.3.1",
     "prettier": "^2.4.1",
     "semantic-release": "^17.4.7",


### PR DESCRIPTION
Jira: [SPK-344](https://mixmaxhq.atlassian.net/browse/SPK-344)

#### Changes Made
* Bump eslint-config-mixmax to enforce return-await
* Run `eslint . --fix`
* Manual fixes as needed to make it lint (please see commit comment)

#### Potential Risks

Most changes were done using `eslint --fix`, so they should be safe. Please focus your review
on the few manual ones, as described in the commit comment.

#### Test Plan

Just lint, unit test, and build.

#### Release Plan

Merge.


[SPK-344]: https://mixmaxhq.atlassian.net/browse/SPK-344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ